### PR TITLE
Update create_cli.py

### DIFF
--- a/ersilia/cli/cmd.py
+++ b/ersilia/cli/cmd.py
@@ -29,9 +29,9 @@ class Command(object):
         m = importlib.import_module("ersilia.cli.commands.close")
         m.close_cmd()
 
-    def current(self):
-        m = importlib.import_module("ersilia.cli.commands.current")
-        m.current_cmd()
+    #def current(self):
+        #m = importlib.import_module("ersilia.cli.commands.current")
+        #m.current_cmd()
 
     def delete(self):
         m = importlib.import_module("ersilia.cli.commands.delete")

--- a/ersilia/cli/cmd.py
+++ b/ersilia/cli/cmd.py
@@ -29,6 +29,10 @@ class Command(object):
         m = importlib.import_module("ersilia.cli.commands.close")
         m.close_cmd()
 
+    #def current(self):
+        #m = importlib.import_module("ersilia.cli.commands.current")
+        #m.current_cmd()
+        
     def delete(self):
         m = importlib.import_module("ersilia.cli.commands.delete")
         m.delete_cmd()

--- a/ersilia/cli/cmd.py
+++ b/ersilia/cli/cmd.py
@@ -29,10 +29,6 @@ class Command(object):
         m = importlib.import_module("ersilia.cli.commands.close")
         m.close_cmd()
 
-    #def current(self):
-        #m = importlib.import_module("ersilia.cli.commands.current")
-        #m.current_cmd()
-
     def delete(self):
         m = importlib.import_module("ersilia.cli.commands.delete")
         m.delete_cmd()

--- a/ersilia/cli/cmd.py
+++ b/ersilia/cli/cmd.py
@@ -28,8 +28,7 @@ class Command(object):
     def close(self):
         m = importlib.import_module("ersilia.cli.commands.close")
         m.close_cmd()
-
-        
+  
     def delete(self):
         m = importlib.import_module("ersilia.cli.commands.delete")
         m.delete_cmd()

--- a/ersilia/cli/cmd.py
+++ b/ersilia/cli/cmd.py
@@ -29,9 +29,6 @@ class Command(object):
         m = importlib.import_module("ersilia.cli.commands.close")
         m.close_cmd()
 
-    #def current(self):
-        #m = importlib.import_module("ersilia.cli.commands.current")
-        #m.current_cmd()
         
     def delete(self):
         m = importlib.import_module("ersilia.cli.commands.delete")

--- a/ersilia/cli/commands/current.py
+++ b/ersilia/cli/commands/current.py
@@ -1,4 +1,0 @@
-#from . import ersilia_cli
-#from .. import echo
-#from ...core.session import Session
-

--- a/ersilia/cli/commands/current.py
+++ b/ersilia/cli/commands/current.py
@@ -1,17 +1,4 @@
-from . import ersilia_cli
-from .. import echo
-from ...core.session import Session
+#from . import ersilia_cli
+#from .. import echo
+#from ...core.session import Session
 
-
-def current_cmd():
-    @ersilia_cli.command(
-        short_help="Get identifier of current model",
-        help="Get identifier of currently served model",
-    )
-    def current():
-        session = Session(config_json=None)
-        model_id = session.current_model_id()
-        if model_id is not None:
-            echo("Current model identifier: {0}".format(model_id), fg="blue")
-        else:
-            echo("No model is current served...", fg="yellow")

--- a/ersilia/cli/commands/current.py
+++ b/ersilia/cli/commands/current.py
@@ -1,0 +1,3 @@
+#from . import ersilia_cli
+#from .. import echo
+#from ...core.session import Session

--- a/ersilia/cli/create_cli.py
+++ b/ersilia/cli/create_cli.py
@@ -14,7 +14,6 @@ def create_ersilia_cli():
     cmd.catalog()
     cmd.clear()
     cmd.close()
-    cmd.current()
     cmd.delete()
     cmd.example()
     cmd.fetch()


### PR DESCRIPTION
**Description**
Removal of Ersilia current command

**Changes to be made**

I intend to De-register the `current` command from ersilia cli file (create_cli.py) by locating the cmd.current() line

**Status**

Deleted ` cmd.current()`

**To do**

Remove the implementation command from  .../cli/commands/current.py


Related to #1267